### PR TITLE
Update headers for RN@0.40.0

### DIFF
--- a/ios/RNGeocoder/RNGeocoder.h
+++ b/ios/RNGeocoder/RNGeocoder.h
@@ -1,5 +1,5 @@
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
 
 #import <CoreLocation/CoreLocation.h>
 

--- a/ios/RNGeocoder/RNGeocoder.m
+++ b/ios/RNGeocoder/RNGeocoder.m
@@ -2,7 +2,7 @@
 
 #import <CoreLocation/CoreLocation.h>
 
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 @implementation RCTConvert (CoreLocation)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-geocoder",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "react native geocoding and reverse geocoding",
   "main": "index.js",
   "scripts": {
@@ -42,5 +42,9 @@
   },
   "dependencies": {
     "geolib": "^2.0.21"
+  },
+  "peerDependencies": {
+    "react": ">=15.4.0",
+    "react-native": ">=0.40"
   }
 }


### PR DESCRIPTION
React Native has made a breaking change to header paths in [0.40.0](https://github.com/facebook/react-native/releases/tag/v0.40.0).

Besides fixing the headers, this PR add `RN@0.40` and `React@15.4.0` as
peer depenencies and bump version.

I submit PR to this fork instead because it has newer fixes and the original
author does not seem to maintain it.